### PR TITLE
🎨 Palette: Add keyboard focus and position highlight to hunter cell

### DIFF
--- a/libs/game/feature/src/lib/game.html
+++ b/libs/game/feature/src/lib/game.html
@@ -29,6 +29,8 @@
 
         <lib-game-cell
           [class.escape]="isFirstRow && $first && hasGold"
+          [active]="isHunterCell && !isGameOver"
+          [attr.tabindex]="isHunterCell && !isGameOver ? 0 : null"
           [cell]="cell"
           [showElements]="showElements"
           [showHunter]="showHunter"

--- a/libs/game/ui/src/lib/cell/game-cell.component.html
+++ b/libs/game/ui/src/lib/cell/game-cell.component.html
@@ -1,7 +1,7 @@
 @let cellValue = cell();
 @let content = cellValue.content;
 
-<div class="cell" [class.visited]="cellValue.visited">
+<div class="cell" [class.visited]="cellValue.visited" [class.active]="active()">
   @if (showElements() && content) {
     <lib-cell-content [content]="content" />
   } @else if (showHunter()) {

--- a/libs/game/ui/src/lib/cell/game-cell.component.scss
+++ b/libs/game/ui/src/lib/cell/game-cell.component.scss
@@ -23,6 +23,14 @@
     top: 5px;
     right: 5px;
   }
+
+}
+
+:host:focus-visible .cell,
+.cell.active {
+  outline: 4px solid var(--color-focus);
+  outline-offset: -4px;
+  z-index: 10;
 }
 
 @keyframes fadeFog {

--- a/libs/game/ui/src/lib/cell/game-cell.component.ts
+++ b/libs/game/ui/src/lib/cell/game-cell.component.ts
@@ -24,4 +24,5 @@ export class GameCellComponent {
   readonly showHunter = input.required<boolean>();
   readonly hasLantern = input.required<boolean>();
   readonly hasShield = input.required<boolean>();
+  readonly active = input<boolean>(false);
 }


### PR DESCRIPTION
💡 What: This change adds keyboard focusability and a visual highlight to the hunter's current cell on the game board.

🎯 Why: Previously, the hunter's position was only indicated by the character icon. Keyboard users had no way to focus their current position, and it was sometimes hard to quickly spot the hunter in complex grid layouts.

📸 Visuals: A neon-yellow (var(--color-focus)) 4px outline now appears around the hunter's cell, both as a permanent highlight (`.active`) and when focused via keyboard (`:focus-visible`).

♿ Accessibility: 
- Current cell is now part of the tab order (`tabindex="0"`).
- Uses `:focus-visible` to provide clear feedback for keyboard navigators while remaining unobtrusive for mouse users.
- The focus indicator matches the application's global focus style for consistency.

---
*PR created automatically by Jules for task [1163811024876994766](https://jules.google.com/task/1163811024876994766) started by @chdelucia*