### PR TITLE
Decouple achievements-remote from hardcoded AchieveTypes

### DIFF
--- a/apps/achievements-remote/src/app/achievements/data-access/achievement-service.interface.ts
+++ b/apps/achievements-remote/src/app/achievements/data-access/achievement-service.interface.ts
@@ -1,10 +1,10 @@
 import { InjectionToken, Signal } from '@angular/core';
-import { Achievement, AchieveTypes } from './achievement.model';
+import { Achievement } from './achievement.model';
 
 export interface IAchievementService {
   achievements: Signal<Achievement[]>;
   completed: Signal<Achievement | undefined>;
-  activeAchievement: (id: AchieveTypes | string) => void;
+  activeAchievement: (id: string) => void;
   isAllCompleted: () => void;
 }
 

--- a/apps/achievements-remote/src/app/achievements/data-access/achievement.model.ts
+++ b/apps/achievements-remote/src/app/achievements/data-access/achievement.model.ts
@@ -9,36 +9,3 @@ export interface Achievement {
   rarity: string;
   date?: string;
 }
-
-export enum AchieveTypes {
-  WUMPUSKILLED = 'kill_wumpus',
-  WRAT = 'escape_rat',
-  PICKARROW = 'collect_arrow',
-  PICKHEART = 'collect_heart',
-  PICKBALLS = 'collect_dragonballs',
-  WINHERO = 'hero_escape',
-  BLACKOUT = 'survive_blackout',
-  WINBLACKWOUT = 'survive_blackout_complete',
-  DEATHBYWUMPUES = 'death_by_wumpus',
-  DEATHBYPIT = 'death_by_pit',
-  PICKGOLD = 'collect_gold',
-  DEATHBYBLACKOUT = 'death_during_blackout',
-  HARDHEAD = 'hard_head',
-  WINLARGEMAP = 'large_map_completion',
-  MISSEDSHOT = 'missed_last_arrow',
-  WASTEDARROWS = 'wasted_arrows',
-  SPEEDRUNNER = 'speedrunner',
-  GAMER = 'true_gamer',
-  BLINDWUMPUSKILLED = 'blind_shot',
-  NOVICECARTO = 'novice_cartographer',
-  EXPERTCARTO = 'expert_cartographer',
-  DEATHDUEL = 'death_duel',
-  SNIPER = 'sniper',
-  LASTBREATH = 'last_breath',
-  FINAL = 'completionist',
-  JEDI = 'secret',
-  PENTA = 'pentakill',
-  LEGOLAS = 'legolas',
-  LINK = 'link',
-  LARA = 'lara',
-}

--- a/apps/achievements-remote/src/app/achievements/data-access/achievement.service.mock.ts
+++ b/apps/achievements-remote/src/app/achievements/data-access/achievement.service.mock.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { Signal, signal } from '@angular/core';
 import { Achievement } from './achievement.model';
 import { IAchievementService } from './achievement-service.interface';
 

--- a/apps/achievements-remote/src/app/achievements/data-access/achievement.service.spec.ts
+++ b/apps/achievements-remote/src/app/achievements/data-access/achievement.service.spec.ts
@@ -4,7 +4,6 @@ import {
   LOCALSTORAGE_SERVICE_TOKEN,
   ANALYTICS_SERVICE_TOKEN,
 } from './core-api.model';
-import { AchieveTypes } from './achievement.model';
 import { AchievementsFacade } from './achievements.facade';
 import { signal, WritableSignal } from '@angular/core';
 import { of, throwError } from 'rxjs';
@@ -54,50 +53,51 @@ describe('AchievementService', () => {
 
   it('should unlock achievement when activeAchievement is called', () => {
     service.achievementsSignal.set([
-      { id: AchieveTypes.GAMER, title: 'Gamer', unlocked: false } as any,
+      { id: 'true_gamer', title: 'Gamer', unlocked: false } as any,
     ]);
-    service.activeAchievement(AchieveTypes.GAMER);
-    const gamer = service.achievements().find((a) => a.id === AchieveTypes.GAMER);
+    service.activeAchievement('true_gamer');
+    const gamer = service.achievements().find((a) => a.id === 'true_gamer');
     expect(gamer?.unlocked).toBe(true);
   });
 
   it('should check if all completed', () => {
+    facadeMock.config.set({ appId: 'test', finalAchievementId: 'completionist' });
     service.achievementsSignal.set([
-      { id: AchieveTypes.GAMER, unlocked: true } as any,
-      { id: AchieveTypes.FINAL, unlocked: false } as any,
+      { id: 'true_gamer', unlocked: true } as any,
+      { id: 'completionist', unlocked: false } as any,
     ]);
     service.isAllCompleted();
-    expect(service.achievements().find((a) => a.id === AchieveTypes.FINAL)?.unlocked).toBe(true);
+    expect(service.achievements().find((a) => a.id === 'completionist')?.unlocked).toBe(true);
   });
 
   it('should sync achievements with storage', () => {
     service.achievementsSignal.set([
-      { id: AchieveTypes.GAMER, unlocked: false } as any,
+      { id: 'true_gamer', unlocked: false } as any,
     ]);
-    localStorageMock.getValue.mockReturnValue([AchieveTypes.GAMER]);
+    localStorageMock.getValue.mockReturnValue(['true_gamer']);
     (service as any).syncAchievementsWithStorage();
-    const gamer = service.achievements().find((a) => a.id === AchieveTypes.GAMER);
+    const gamer = service.achievements().find((a) => a.id === 'true_gamer');
     expect(gamer?.unlocked).toBe(true);
   });
 
   it('should buffer activeAchievement if list not loaded', () => {
-    service.activeAchievement(AchieveTypes.GAMER);
+    service.activeAchievement('true_gamer');
     expect(service.achievements().length).toBe(0);
-    expect((service as any).activeBuffer).toContain(AchieveTypes.GAMER);
+    expect((service as any).activeBuffer).toContain('true_gamer');
   });
 
   it('should process buffer after list is loaded', () => {
-    const mockAchieve = { id: AchieveTypes.GAMER, unlocked: false, title: 'G' };
+    const mockAchieve = { id: 'true_gamer', unlocked: false, title: 'G' };
     httpMock.get.mockReturnValue(of([mockAchieve]));
 
-    service.activeAchievement(AchieveTypes.GAMER);
-    expect((service as any).activeBuffer).toContain(AchieveTypes.GAMER);
+    service.activeAchievement('true_gamer');
+    expect((service as any).activeBuffer).toContain('true_gamer');
 
     facadeMock.config.set({ appId: 'test' });
     TestBed.flushEffects();
 
     expect(service.achievements().length).toBe(1);
-    expect(service.achievements()[0].id).toBe(AchieveTypes.GAMER);
+    expect(service.achievements()[0].id).toBe('true_gamer');
     // Note: processBuffer calls activeAchievement which updates the signal
     expect(service.achievements()[0].unlocked).toBe(true);
     expect((service as any).activeBuffer.length).toBe(0);
@@ -105,9 +105,9 @@ describe('AchievementService', () => {
 
   it('should handle achievement-unlocked window event', () => {
     const activeSpy = jest.spyOn(service, 'activeAchievement');
-    const event = new CustomEvent('achievement-unlocked', { detail: { id: AchieveTypes.GAMER } });
+    const event = new CustomEvent('achievement-unlocked', { detail: { id: 'true_gamer' } });
     window.dispatchEvent(event);
-    expect(activeSpy).toHaveBeenCalledWith(AchieveTypes.GAMER);
+    expect(activeSpy).toHaveBeenCalledWith('true_gamer');
   });
 
   it('should update local storage when an achievement is unlocked', () => {

--- a/apps/achievements-remote/src/app/achievements/data-access/achievement.service.ts
+++ b/apps/achievements-remote/src/app/achievements/data-access/achievement.service.ts
@@ -1,6 +1,6 @@
 import { effect, inject, Injectable, signal, untracked } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Achievement, AchieveTypes } from './achievement.model';
+import { Achievement } from './achievement.model';
 import {
   ANALYTICS_SERVICE_TOKEN,
   LOCALSTORAGE_SERVICE_TOKEN,
@@ -24,7 +24,7 @@ export class AchievementService implements IAchievementService {
   private readonly facade = inject(AchievementsFacade);
   private readonly http = inject(HttpClient);
 
-  private activeBuffer: (AchieveTypes | string)[] = [];
+  private activeBuffer: string[] = [];
 
   constructor() {
     this.listenForExternalAchievements();
@@ -84,7 +84,7 @@ export class AchievementService implements IAchievementService {
     return this.localStoreService.getValue<string[]>(this.storageKey) || [];
   }
 
-  activeAchievement(id: AchieveTypes | string): void {
+  activeAchievement(id: string): void {
     const achievements = this.achievementsSignal();
     if (achievements.length === 0) {
       this.activeBuffer.push(id);
@@ -110,8 +110,9 @@ export class AchievementService implements IAchievementService {
   isAllCompleted(): void {
     const achievements = this.achievementsSignal();
     const victory = achievements.filter((x) => x.unlocked);
-    if (achievements.length > 0 && achievements.length - victory.length <= 1) {
-      this.activeAchievement(AchieveTypes.FINAL);
+    const finalId = this.facade.config()?.finalAchievementId;
+    if (finalId && achievements.length > 0 && achievements.length - victory.length <= 1) {
+      this.activeAchievement(finalId);
     }
   }
 }

--- a/apps/achievements-remote/src/app/achievements/data-access/achievements.facade.ts
+++ b/apps/achievements-remote/src/app/achievements/data-access/achievements.facade.ts
@@ -6,7 +6,7 @@ const ACHIEVEMENTS_EVENT = 'ACHIEVEMENTS_CONFIG';
 @Injectable({ providedIn: 'root' })
 export class AchievementsFacade {
   private readonly bus = inject(MiniBusService);
-  config = signal<{ appId: string } | null>(null);
+  config = signal<{ appId: string; finalAchievementId?: string } | null>(null);
 
   constructor() {
     this.bus.listen(ACHIEVEMENTS_EVENT, (config) => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -60,7 +60,10 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.miniBus.emit('ACHIEVEMENTS_CONFIG', { appId: 'hunt-the-bishomalo' });
+    this.miniBus.emit('ACHIEVEMENTS_CONFIG', {
+      appId: 'hunt-the-bishomalo',
+      finalAchievementId: 'completionist',
+    });
 
     this.preloadRemotes();
 


### PR DESCRIPTION
This PR decouples the `achievements-remote` application from the hardcoded `AchieveTypes` enum. The remote now operates entirely on string identifiers, allowing consuming applications to define their own achievement sets.

Key changes:
- `AchieveTypes` enum removed from `achievements-remote`.
- `AchievementsFacade` now accepts an optional `finalAchievementId` in its configuration.
- `AchievementService.isAllCompleted()` uses the configured `finalAchievementId` to trigger the final achievement.
- The shell application (`hunt-the-bishomalo`) now explicitly provides the `appId` and `finalAchievementId` during initialization.
- All remote tests have been updated to use string literals, ensuring the remote remains generic and reusable.

---
*PR created automatically by Jules for task [16316450791158698550](https://jules.google.com/task/16316450791158698550) started by @chdelucia*