### PR TITLE
⚡ Bolt: enable preloading for shop component

### DIFF
--- a/libs/shop/shell/src/lib/shop.routes.ts
+++ b/libs/shop/shell/src/lib/shop.routes.ts
@@ -3,6 +3,7 @@ import { Routes } from '@angular/router';
 export const shopRoutes: Routes = [
   {
     path: '',
-    loadComponent: () => import('@hunt-the-bishomalo/shop/feature').then(m => m.ShopComponent)
-  }
+    loadComponent: () => import('@hunt-the-bishomalo/shop/feature').then((m) => m.ShopComponent),
+    data: { preload: true },
+  },
 ];


### PR DESCRIPTION
This change enables preloading for the shop feature by adding the `preload: true` flag to its route configuration. This ensures that the `ShopComponent` is fetched in the background when the browser is idle, using the application's `IdlePreloadingStrategy`.

---
*PR created automatically by Jules for task [18366501568262373581](https://jules.google.com/task/18366501568262373581) started by @chdelucia*