### PR TITLE
🛡️ Sentinel: [security improvement] Harden LocalstorageService against prototype pollution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,6 +8,21 @@
 **Learning:** Debugging features that allow dynamic configuration changes can become a persistent hijacking vector if not strictly restricted to non-production environments.
 **Prevention:** Always wrap environment-specific debugging or configuration override logic in strict checks (e.g., `if (isDev)`) to ensure they cannot be exploited in production.
 
+## 2025-05-23 - [Prototype Pollution in MiniBusService]
+**Vulnerability:** The `MiniBusService` used a plain object as an event store, making it susceptible to Prototype Pollution if malicious event names (e.g., `__proto__`) were emitted.
+**Learning:** Shared event systems that persist state in plain objects must be hardened against prototype-related keys to prevent global object pollution.
+**Prevention:** Use `Object.create(null)` for internal stores and explicitly block forbidden keys like `__proto__`, `constructor`, and `prototype`.
+
+## 2025-05-23 - [Client-side Path Traversal in AchievementService]
+**Vulnerability:** The `AchievementService` used the `appId` from an external event directly in a fetch URL, which could allow fetching unauthorized local files if manipulated.
+**Learning:** Data received from cross-component communication or events should be treated as untrusted and sanitized before use in security-sensitive operations like URL construction.
+**Prevention:** Always sanitize identifiers using strict regex (e.g., `/[^a-zA-Z0-9\-_]/g`) before including them in file paths or API requests.
+
+## 2025-05-23 - [Prototype Pollution in LocalstorageService]
+**Vulnerability:** The `LocalstorageService` parsed JSON from `localStorage` without sanitization, allowing malicious data to pollute the object prototype or inject dangerous keys.
+**Learning:** Data retrieved from `localStorage` should be treated as untrusted. Using a `JSON.parse` reviver is an efficient way to strip forbidden keys like `__proto__` during parsing.
+**Prevention:** Always sanitize data from persistent client-side storage. A `JSON.parse` reviver can strip `__proto__`, `constructor`, and `prototype` to prevent prototype pollution while maintaining object compatibility.
+
 ## 2026-03-31 - [Harden CSP by removing unsafe-inline from script-src]
 **Vulnerability:** The application used an inline script for Google Tag Manager, requiring `'unsafe-inline'` in the CSP's `script-src` directive, which increased the risk of XSS.
 **Learning:** Inline scripts, even for legitimate purposes like analytics, create a significant security gap. Moving them to external files allows for a much stricter CSP.
@@ -33,19 +48,7 @@
 **Learning:** Default or placeholder configurations for monitoring tools can create security gaps if not reviewed and updated to reflect the actual environment. Whitelisting only trusted domains prevents accidental data leakage.
 **Prevention:** Always audit monitoring tool configurations (like Sentry, LogRocket, etc.) to ensure that only authorized domains are whitelisted for sensitive operations like distributed tracing header propagation.
 
-<<<<<<< sentinel/harden-services-and-sanitize-inputs-4627285246135265910
-## 2025-05-23 - [Prototype Pollution in MiniBusService]
-**Vulnerability:** The `MiniBusService` used a plain object as an event store, making it susceptible to Prototype Pollution if malicious event names (e.g., `__proto__`) were emitted.
-**Learning:** Shared event systems that persist state in plain objects must be hardened against prototype-related keys to prevent global object pollution.
-**Prevention:** Use `Object.create(null)` for internal stores and explicitly block forbidden keys like `__proto__`, `constructor`, and `prototype`.
-
-## 2025-05-23 - [Client-side Path Traversal in AchievementService]
-**Vulnerability:** The `AchievementService` used the `appId` from an external event directly in a fetch URL, which could allow fetching unauthorized local files if manipulated.
-**Learning:** Data received from cross-component communication or events should be treated as untrusted and sanitized before use in security-sensitive operations like URL construction.
-**Prevention:** Always sanitize identifiers using strict regex (e.g., `/[^a-zA-Z0-9\-_]/g`) before including them in file paths or API requests.
-=======
 ## 2026-04-05 - [Harden Sentry tracePropagationTargets with Anchored Regex]
 **Vulnerability:** Sentry's `tracePropagationTargets` used loose string matches and unanchored regular expressions, which could allow sensitive tracing headers (`sentry-trace`, `baggage`) to be leaked to malicious domains that included the whitelisted domain as a substring or prefix (e.g., `hunt-the-bishomalo.vercel.app.malicious.com`).
 **Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
 **Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
->>>>>>> master

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
@@ -32,6 +32,21 @@ describe('LocalstorageService', () => {
       expect(service.getValue('test-key')).toEqual(data);
     });
 
+    it('should sanitize the parsed object to prevent prototype pollution', () => {
+      const maliciousJson = '{"foo": "bar", "__proto__": {"polluted": true}}';
+      localStorage.setItem('test-key', maliciousJson);
+
+      const result = service.getValue<any>('test-key');
+
+      expect(result.foo).toBe('bar');
+      expect(result.polluted).toBeUndefined();
+
+      // Ensure it's still a standard object with Object prototype
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+      // Ensure the prototype itself is not polluted
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
+
     it('should return null and log error if parsing fails in dev mode', () => {
       (isDevMode as jest.Mock).mockReturnValue(true);
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
@@ -5,6 +5,8 @@ import { ILocalstorageService } from '@hunt-the-bishomalo/core/api';
   providedIn: 'root',
 })
 export class LocalstorageService implements ILocalstorageService {
+  private readonly forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
+
   getValue<T>(key: string): T | null {
     const item = localStorage.getItem(key);
     if (!item) {
@@ -12,7 +14,12 @@ export class LocalstorageService implements ILocalstorageService {
     }
 
     try {
-      return JSON.parse(item);
+      return JSON.parse(item, (k, v) => {
+        if (this.forbiddenKeys.includes(k)) {
+          return undefined;
+        }
+        return v;
+      });
     } catch (e) {
       if (isDevMode()) console.log(e);
       return null;


### PR DESCRIPTION
Harden the `LocalstorageService` by implementing a `JSON.parse` reviver that automatically strips prototype-polluting keys (`__proto__`, `constructor`, `prototype`) from data retrieved from `localStorage`. This provides defense-in-depth against malicious or corrupted persistent data.

- Modified `LocalstorageService` to use a reviver function.
- Added a comprehensive test case in `LocalstorageService` spec.
- Updated `sentinel.md` with learnings.
- Verified with `nx test core-data-access` and `nx lint core-data-access`.

---
*PR created automatically by Jules for task [8843416923472050965](https://jules.google.com/task/8843416923472050965) started by @chdelucia*