### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Prototype Pollution in LocalStorage and Config Loader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,7 +33,6 @@
 **Learning:** Default or placeholder configurations for monitoring tools can create security gaps if not reviewed and updated to reflect the actual environment. Whitelisting only trusted domains prevents accidental data leakage.
 **Prevention:** Always audit monitoring tool configurations (like Sentry, LogRocket, etc.) to ensure that only authorized domains are whitelisted for sensitive operations like distributed tracing header propagation.
 
-<<<<<<< sentinel/harden-services-and-sanitize-inputs-4627285246135265910
 ## 2025-05-23 - [Prototype Pollution in MiniBusService]
 **Vulnerability:** The `MiniBusService` used a plain object as an event store, making it susceptible to Prototype Pollution if malicious event names (e.g., `__proto__`) were emitted.
 **Learning:** Shared event systems that persist state in plain objects must be hardened against prototype-related keys to prevent global object pollution.
@@ -43,9 +42,13 @@
 **Vulnerability:** The `AchievementService` used the `appId` from an external event directly in a fetch URL, which could allow fetching unauthorized local files if manipulated.
 **Learning:** Data received from cross-component communication or events should be treated as untrusted and sanitized before use in security-sensitive operations like URL construction.
 **Prevention:** Always sanitize identifiers using strict regex (e.g., `/[^a-zA-Z0-9\-_]/g`) before including them in file paths or API requests.
-=======
+
 ## 2026-04-05 - [Harden Sentry tracePropagationTargets with Anchored Regex]
 **Vulnerability:** Sentry's `tracePropagationTargets` used loose string matches and unanchored regular expressions, which could allow sensitive tracing headers (`sentry-trace`, `baggage`) to be leaked to malicious domains that included the whitelisted domain as a substring or prefix (e.g., `hunt-the-bishomalo.vercel.app.malicious.com`).
 **Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
 **Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
->>>>>>> master
+
+## 2025-05-24 - [Centralized Prototype Pollution Protection]
+**Vulnerability:** Parsing untrusted JSON data from `localStorage` (e.g., game state, settings, or MFE configuration overrides) without sanitization can lead to Prototype Pollution if malicious keys like `__proto__` are present.
+**Learning:** While modern JS engines might not directly pollute the global prototype via `JSON.parse`, these properties can still be exploited during subsequent object merges or clones.
+**Prevention:** Use a centralized `prototypePollutionReviver` with `JSON.parse` at all entry points for external data to strip forbidden keys (`__proto__`, `constructor`, `prototype`) at the source.

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
@@ -32,6 +32,17 @@ describe('LocalstorageService', () => {
       expect(service.getValue('test-key')).toEqual(data);
     });
 
+    it('should strip prototype pollution keys when retrieving value', () => {
+      const maliciousData = '{"foo": "bar", "__proto__": {"polluted": "true"}}';
+      localStorage.setItem('test-key', maliciousData);
+
+      const retrieved = service.getValue<Record<string, any>>('test-key');
+      expect(retrieved?.['foo']).toBe('bar');
+      // Use bracket notation or cast to any to check for __proto__ presence without triggering pollution in the check
+      expect(Object.prototype.hasOwnProperty.call(retrieved!, '__proto__')).toBe(false);
+      expect(Object.getPrototypeOf(retrieved!)).toBe(Object.prototype);
+    });
+
     it('should return null and log error if parsing fails in dev mode', () => {
       (isDevMode as jest.Mock).mockReturnValue(true);
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, isDevMode } from '@angular/core';
 import { ILocalstorageService } from '@hunt-the-bishomalo/core/api';
+import { prototypePollutionReviver } from '@hunt-the-bishomalo/shared-util';
 
 @Injectable({
   providedIn: 'root',
@@ -12,7 +13,7 @@ export class LocalstorageService implements ILocalstorageService {
     }
 
     try {
-      return JSON.parse(item);
+      return JSON.parse(item, prototypePollutionReviver);
     } catch (e) {
       if (isDevMode()) console.log(e);
       return null;

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/transloco-testing';
+export * from './lib/security.util';

--- a/libs/shared/util/src/lib/security.util.spec.ts
+++ b/libs/shared/util/src/lib/security.util.spec.ts
@@ -1,0 +1,74 @@
+import { prototypePollutionReviver, sanitizeObject } from './security.util';
+
+describe('Security Utilities', () => {
+  describe('prototypePollutionReviver', () => {
+    it('should strip forbidden keys', () => {
+      const json = '{"foo": "bar", "__proto__": {"polluted": "true"}, "constructor": "evil", "prototype": "dangerous"}';
+      const parsed = JSON.parse(json, prototypePollutionReviver);
+
+      expect(parsed.foo).toBe('bar');
+      // When using reviver and returning undefined, the key is omitted from the object.
+      // Use Object.prototype.hasOwnProperty.call to satisfy linting
+      expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(parsed, 'constructor')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(parsed, 'prototype')).toBe(false);
+
+      // Verify it's not actually polluted
+      expect((parsed as Record<string, unknown>)['polluted']).toBeUndefined();
+    });
+
+    it('should handle nested objects', () => {
+      const json = '{"nested": {"__proto__": {"a": 1}}}';
+      const parsed = JSON.parse(json, prototypePollutionReviver);
+      expect(Object.prototype.hasOwnProperty.call(parsed.nested, '__proto__')).toBe(false);
+    });
+  });
+
+  describe('sanitizeObject', () => {
+    it('should remove forbidden keys from object', () => {
+      const obj = {
+        a: 1,
+        __proto__: { polluted: true },
+        constructor: { name: 'evil' },
+        prototype: { some: 'thing' }
+      } as unknown as Record<string, unknown>;
+
+      const sanitized = sanitizeObject(obj) as Record<string, unknown>;
+
+      expect(sanitized['a']).toBe(1);
+      expect(Object.prototype.hasOwnProperty.call(sanitized, '__proto__')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(sanitized, 'constructor')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(sanitized, 'prototype')).toBe(false);
+    });
+
+    it('should recursively sanitize nested objects and arrays', () => {
+      const obj = {
+        nested: {
+          __proto__: { p: 1 },
+          valid: true
+        },
+        arr: [
+          { __proto__: { p: 2 }, ok: true },
+          "plain"
+        ]
+      } as unknown as Record<string, unknown>;
+
+      const sanitized = sanitizeObject(obj) as Record<string, unknown>;
+
+      const nested = sanitized['nested'] as Record<string, unknown>;
+      expect(nested['valid']).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(nested, '__proto__')).toBe(false);
+
+      const arr = sanitized['arr'] as any[];
+      expect(arr[0]['ok']).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(arr[0], '__proto__')).toBe(false);
+    });
+
+    it('should return null/undefined/primitives as is', () => {
+      expect(sanitizeObject(null)).toBeNull();
+      expect(sanitizeObject(undefined)).toBeUndefined();
+      expect(sanitizeObject(123)).toBe(123);
+      expect(sanitizeObject("string")).toBe("string");
+    });
+  });
+});

--- a/libs/shared/util/src/lib/security.util.ts
+++ b/libs/shared/util/src/lib/security.util.ts
@@ -1,0 +1,36 @@
+export const FORBIDDEN_PROTOTYPE_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * A JSON.parse reviver function that strips forbidden prototype-related keys
+ * to prevent Prototype Pollution vulnerabilities.
+ */
+export function prototypePollutionReviver(key: string, value: unknown): unknown {
+  if (FORBIDDEN_PROTOTYPE_KEYS.includes(key)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Recursively sanitizes an object by removing forbidden prototype-related keys.
+ * Useful for cases where JSON.parse reviver cannot be used or for pre-existing objects.
+ */
+export function sanitizeObject<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeObject) as unknown as T;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (!FORBIDDEN_PROTOTYPE_KEYS.includes(key)) {
+        sanitized[key] = sanitizeObject((obj as Record<string, unknown>)[key]);
+      }
+    }
+  }
+  return sanitized as T;
+}

--- a/src/app/utils/config-loader.ts
+++ b/src/app/utils/config-loader.ts
@@ -15,7 +15,10 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
     const localOverride = localStorage.getItem('MFE_REMOTES_OVERRIDE');
     if (localOverride) {
       try {
-        return JSON.parse(localOverride) as RemoteConfig;
+        // Use a reviver to prevent prototype pollution from local storage overrides.
+        // This ensures that malicious keys like __proto__ are not injected into the config object.
+        const { prototypePollutionReviver } = await import('@hunt-the-bishomalo/shared-util');
+        return JSON.parse(localOverride, prototypePollutionReviver) as RemoteConfig;
       } catch (e) {
         globalThis.console.warn('Invalid MFE_REMOTES_OVERRIDE found in localStorage', e);
       }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential Prototype Pollution when parsing untrusted JSON data from `localStorage`.
🎯 Impact: Malicious users could inject properties into the prototype of objects, potentially leading to remote code execution or application crashes if the resulting objects are merged into others.
🔧 Fix: Implemented a centralized `prototypePollutionReviver` that strips `__proto__`, `constructor`, and `prototype` keys during `JSON.parse` operations. Applied this reviver to `LocalstorageService` and `config-loader.ts`.
✅ Verification: Added unit tests in `security.util.spec.ts` and updated `localstorage.service.spec.ts` to verify that forbidden keys are correctly stripped. Ran full workspace tests and linting.

---
*PR created automatically by Jules for task [9145557906946028161](https://jules.google.com/task/9145557906946028161) started by @chdelucia*