### PR TITLE
🎨 Palette: Improve GameConfig accessibility

### DIFF
--- a/libs/config/feature/src/lib/game-config.component.html
+++ b/libs/config/feature/src/lib/game-config.component.html
@@ -7,13 +7,24 @@
     @let playerState = configForm.player();
     <label for="player">{{ 'config.playerNameLabel' | transloco }}</label>
     <div class="input-wrapper">
-      <input id="player" type="text" [formField]="configForm.player" />
-      <span class="char-counter" [class.limit-reached]="playerState.value().length >= 20">
+      <input
+        id="player"
+        type="text"
+        [formField]="configForm.player"
+        [attr.aria-describedby]="
+          'player-counter' + (playerState.touched() && playerState.errors().length > 0 ? ' player-error' : '')
+        "
+      />
+      <span
+        id="player-counter"
+        class="char-counter"
+        [class.limit-reached]="playerState.value().length >= 20"
+      >
         {{ playerState.value().length }}/20
       </span>
     </div>
     @if (playerState.touched() && playerState.errors().length > 0) {
-      <span class="error-message" role="alert">
+      <span id="player-error" class="error-message" role="alert">
         {{ 'config.error.' + playerState.errors()[0].kind | transloco }}
       </span>
     }
@@ -21,7 +32,11 @@
 
   <div class="form-group">
     <label for="difficulty">{{ 'config.difficultyLabel' | transloco }}</label>
-    <select id="difficulty" [formField]="configForm.difficulty">
+    <select
+      id="difficulty"
+      [formField]="configForm.difficulty"
+      aria-describedby="difficulty-desc"
+    >
       <option value="easy">{{ 'config.difficultyEasy' | transloco }}</option>
       <option value="normal">{{ 'config.difficultyNormal' | transloco }}</option>
       <option value="hard">{{ 'config.difficultyHard' | transloco }}</option>
@@ -30,7 +45,7 @@
 
   @let options = configs[this.model().difficulty];
 
-  <div class="difficulty-description">
+  <div id="difficulty-desc" class="difficulty-description">
     <p>
       {{
       'config.difficultyDescription'


### PR DESCRIPTION
### 💡 What
Added `aria-describedby` associations to the player name input and difficulty selection in the game configuration form.

### 🎯 Why
To ensure screen reader users receive important context like character counts, validation errors, and difficulty descriptions that were previously not linked to the inputs.

### 📸 Before/After
Visuals were generated and verified during the frontend verification step. The changes are purely functional for assistive technologies and do not alter the visual design.

### ♿ Accessibility
- Linked `#player` input to `#player-counter` and `#player-error` (dynamically).
- Linked `#difficulty` select to `#difficulty-desc`.
- Ensured error messages have `role="alert"` for proper announcement.

---
*PR created automatically by Jules for task [15226151639941177148](https://jules.google.com/task/15226151639941177148) started by @chdelucia*