### PR TITLE
🛡️ Sentinel: Harden localStorage parsing against Prototype Pollution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -49,3 +49,8 @@
 **Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
 **Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
 >>>>>>> master
+
+## 2025-05-24 - [Harden JSON.parse against Prototype Pollution]
+**Vulnerability:** Use of `JSON.parse` on data from `localStorage` without a reviver allowed for potential Prototype Pollution if the stored data was maliciously manipulated.
+**Learning:** `localStorage` should be treated as an untrusted input source. Standard `JSON.parse` can be exploited to inject properties into the `Object.prototype` or override critical object properties.
+**Prevention:** Always use a reviver function with `JSON.parse` that strips forbidden keys like `__proto__`, `constructor`, and `prototype` when handling data from potentially untrusted sources like `localStorage`.

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
@@ -49,6 +49,20 @@ describe('LocalstorageService', () => {
       expect(consoleSpy).not.toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    it('should prevent prototype pollution when parsing JSON', () => {
+      const maliciousPayload = '{"__proto__": {"polluted": "yes"}, "constructor": "malicious", "prototype": "malicious", "foo": "bar"}';
+      localStorage.setItem('malicious-key', maliciousPayload);
+
+      const result = service.getValue<any>('malicious-key');
+
+      expect(result.foo).toBe('bar');
+      expect(result.__proto__.polluted).toBeUndefined();
+      // 'constructor' of the top-level object is not removed by JSON.parse reviver if it's not nested
+      // because the reviver is called for each key-value pair, and the final object is not 'revived' for its own inherited properties.
+      // However, we care about preventing the OVERRIDE of these properties.
+      expect(({} as any).polluted).toBeUndefined();
+    });
   });
 
   describe('setValue', () => {

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, isDevMode } from '@angular/core';
 import { ILocalstorageService } from '@hunt-the-bishomalo/core/api';
+import { prototypePollutionReviver } from '@hunt-the-bishomalo/shared-util';
 
 @Injectable({
   providedIn: 'root',
@@ -12,7 +13,7 @@ export class LocalstorageService implements ILocalstorageService {
     }
 
     try {
-      return JSON.parse(item);
+      return JSON.parse(item, prototypePollutionReviver);
     } catch (e) {
       if (isDevMode()) console.log(e);
       return null;

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/transloco-testing';
+export * from './lib/security';

--- a/libs/shared/util/src/lib/security.ts
+++ b/libs/shared/util/src/lib/security.ts
@@ -1,0 +1,11 @@
+/**
+ * Reviver function for JSON.parse to prevent prototype pollution.
+ * It strips forbidden keys like __proto__, constructor, and prototype.
+ */
+export const prototypePollutionReviver = (key: string, value: any): any => {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined;
+  }
+
+  return value;
+};

--- a/src/app/utils/config-loader.ts
+++ b/src/app/utils/config-loader.ts
@@ -1,3 +1,5 @@
+import { prototypePollutionReviver } from '@hunt-the-bishomalo/shared-util';
+
 export interface RemoteConfig {
   remotes: Record<string, string>;
 }
@@ -15,7 +17,7 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
     const localOverride = localStorage.getItem('MFE_REMOTES_OVERRIDE');
     if (localOverride) {
       try {
-        return JSON.parse(localOverride) as RemoteConfig;
+        return JSON.parse(localOverride, prototypePollutionReviver) as RemoteConfig;
       } catch (e) {
         globalThis.console.warn('Invalid MFE_REMOTES_OVERRIDE found in localStorage', e);
       }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential Prototype Pollution when parsing untrusted data from `localStorage`.
🎯 Impact: Malicious data in `localStorage` could hijack the application's prototype chain, leading to XSS or stability issues.
🔧 Fix: Implemented a global `prototypePollutionReviver` for `JSON.parse` that strips `__proto__`, `constructor`, and `prototype` keys.
✅ Verification: Added a dedicated test case in `LocalstorageService` and verified that all workspace tests and lints pass.

---
*PR created automatically by Jules for task [1408020524207896126](https://jules.google.com/task/1408020524207896126) started by @chdelucia*