### PR TITLE
🛡️ Sentinel: [security improvement] Harden JSON parsing against Prototype Pollution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,7 +33,11 @@
 **Learning:** Default or placeholder configurations for monitoring tools can create security gaps if not reviewed and updated to reflect the actual environment. Whitelisting only trusted domains prevents accidental data leakage.
 **Prevention:** Always audit monitoring tool configurations (like Sentry, LogRocket, etc.) to ensure that only authorized domains are whitelisted for sensitive operations like distributed tracing header propagation.
 
-<<<<<<< sentinel/harden-services-and-sanitize-inputs-4627285246135265910
+## 2026-04-05 - [Harden Sentry tracePropagationTargets with Anchored Regex]
+**Vulnerability:** Sentry's `tracePropagationTargets` used loose string matches and unanchored regular expressions, which could allow sensitive tracing headers (`sentry-trace`, `baggage`) to be leaked to malicious domains that included the whitelisted domain as a substring or prefix (e.g., `hunt-the-bishomalo.vercel.app.malicious.com`).
+**Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
+**Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
+
 ## 2025-05-23 - [Prototype Pollution in MiniBusService]
 **Vulnerability:** The `MiniBusService` used a plain object as an event store, making it susceptible to Prototype Pollution if malicious event names (e.g., `__proto__`) were emitted.
 **Learning:** Shared event systems that persist state in plain objects must be hardened against prototype-related keys to prevent global object pollution.
@@ -43,9 +47,8 @@
 **Vulnerability:** The `AchievementService` used the `appId` from an external event directly in a fetch URL, which could allow fetching unauthorized local files if manipulated.
 **Learning:** Data received from cross-component communication or events should be treated as untrusted and sanitized before use in security-sensitive operations like URL construction.
 **Prevention:** Always sanitize identifiers using strict regex (e.g., `/[^a-zA-Z0-9\-_]/g`) before including them in file paths or API requests.
-=======
-## 2026-04-05 - [Harden Sentry tracePropagationTargets with Anchored Regex]
-**Vulnerability:** Sentry's `tracePropagationTargets` used loose string matches and unanchored regular expressions, which could allow sensitive tracing headers (`sentry-trace`, `baggage`) to be leaked to malicious domains that included the whitelisted domain as a substring or prefix (e.g., `hunt-the-bishomalo.vercel.app.malicious.com`).
-**Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
-**Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
->>>>>>> master
+
+## 2026-04-26 - [Harden JSON parsing against Prototype Pollution]
+**Vulnerability:** `JSON.parse` was used on untrusted data from `localStorage` and remote configurations without any sanitization, leaving the application vulnerable to Prototype Pollution.
+**Learning:** Standard `JSON.parse` will process special keys like `__proto__`. If the parsed object is then merged with other objects, it can pollute the global `Object.prototype`.
+**Prevention:** Always use a reviver function with `JSON.parse` to strip forbidden keys (`__proto__`, `constructor`, `prototype`) and recursively sanitize already-parsed objects before merging them into application state.

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
@@ -75,4 +75,16 @@ describe('LocalstorageService', () => {
       expect(localStorage.length).toBe(0);
     });
   });
+
+  describe('security', () => {
+    it('should prevent prototype pollution during parsing', () => {
+      const pollutedPayload = '{"__proto__": {"polluted": true}, "normal": "value"}';
+      localStorage.setItem('polluted', pollutedPayload);
+
+      const value = service.getValue<any>('polluted');
+
+      expect(value.normal).toBe('value');
+      expect(Object.prototype.hasOwnProperty.call(value, '__proto__')).toBe(false);
+    });
+  });
 });

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, isDevMode } from '@angular/core';
 import { ILocalstorageService } from '@hunt-the-bishomalo/core/api';
+import { prototypePollutionReviver } from '@hunt-the-bishomalo/shared-util';
 
 @Injectable({
   providedIn: 'root',
@@ -12,7 +13,7 @@ export class LocalstorageService implements ILocalstorageService {
     }
 
     try {
-      return JSON.parse(item);
+      return JSON.parse(item, prototypePollutionReviver);
     } catch (e) {
       if (isDevMode()) console.log(e);
       return null;

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/transloco-testing';
+export * from './lib/security.util';

--- a/libs/shared/util/src/lib/security.util.spec.ts
+++ b/libs/shared/util/src/lib/security.util.spec.ts
@@ -1,0 +1,64 @@
+import { prototypePollutionReviver, sanitizeObject } from './security.util';
+
+describe('Security Utilities', () => {
+  const hasOwn = (obj: any, key: string) => Object.prototype.hasOwnProperty.call(obj, key);
+
+  describe('prototypePollutionReviver', () => {
+    it('should strip forbidden keys', () => {
+      const payload = '{"foo": "bar", "__proto__": {"polluted": "true"}, "constructor": "evil", "prototype": "dangerous"}';
+      const parsed = JSON.parse(payload, prototypePollutionReviver);
+
+      expect(parsed.foo).toBe('bar');
+      expect(hasOwn(parsed, '__proto__')).toBe(false);
+      expect(hasOwn(parsed, 'constructor')).toBe(false);
+      expect(hasOwn(parsed, 'prototype')).toBe(false);
+    });
+
+    it('should handle nested forbidden keys', () => {
+      const payload = '{"nested": {"__proto__": {"polluted": "true"}}}';
+      const parsed = JSON.parse(payload, prototypePollutionReviver);
+
+      expect(hasOwn(parsed.nested, '__proto__')).toBe(false);
+    });
+
+    it('should allow normal keys', () => {
+      const payload = '{"a": 1, "b": "2", "c": true}';
+      const parsed = JSON.parse(payload, prototypePollutionReviver);
+
+      expect(parsed).toEqual({ a: 1, b: '2', c: true });
+    });
+  });
+
+  describe('sanitizeObject', () => {
+    it('should remove forbidden keys recursively', () => {
+      const obj = {
+        foo: 'bar',
+        __proto__: { polluted: 'true' },
+        nested: {
+          constructor: 'evil',
+          deep: {
+            prototype: 'dangerous',
+            valid: 123,
+          },
+        },
+        list: [{ __proto__: 'polluted' }, { valid: true }],
+      };
+
+      const sanitized = sanitizeObject(obj);
+
+      expect(sanitized.foo).toBe('bar');
+      expect(hasOwn(sanitized, '__proto__')).toBe(false);
+      expect(hasOwn(sanitized.nested, 'constructor')).toBe(false);
+      expect(hasOwn(sanitized.nested.deep, 'prototype')).toBe(false);
+      expect(sanitized.nested.deep.valid).toBe(123);
+      expect(hasOwn(sanitized.list[0], '__proto__')).toBe(false);
+      expect(sanitized.list[1]).toEqual({ valid: true });
+    });
+
+    it('should return non-objects as is', () => {
+      expect(sanitizeObject(null)).toBeNull();
+      expect(sanitizeObject(123)).toBe(123);
+      expect(sanitizeObject('string')).toBe('string');
+    });
+  });
+});

--- a/libs/shared/util/src/lib/security.util.ts
+++ b/libs/shared/util/src/lib/security.util.ts
@@ -1,0 +1,32 @@
+const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * A reviver function for JSON.parse that strips forbidden keys to prevent Prototype Pollution.
+ */
+export function prototypePollutionReviver(key: string, value: any): any {
+  if (FORBIDDEN_KEYS.includes(key)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Recursively sanitizes an object by removing forbidden keys.
+ */
+export function sanitizeObject<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeObject) as any;
+  }
+
+  const sanitized: any = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key) && !FORBIDDEN_KEYS.includes(key)) {
+      sanitized[key] = sanitizeObject((obj as any)[key]);
+    }
+  }
+  return sanitized;
+}

--- a/src/app/utils/config-loader.ts
+++ b/src/app/utils/config-loader.ts
@@ -1,3 +1,5 @@
+import { prototypePollutionReviver, sanitizeObject } from '@hunt-the-bishomalo/shared-util';
+
 export interface RemoteConfig {
   remotes: Record<string, string>;
 }
@@ -15,7 +17,7 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
     const localOverride = localStorage.getItem('MFE_REMOTES_OVERRIDE');
     if (localOverride) {
       try {
-        return JSON.parse(localOverride) as RemoteConfig;
+        return JSON.parse(localOverride, prototypePollutionReviver) as RemoteConfig;
       } catch (e) {
         globalThis.console.warn('Invalid MFE_REMOTES_OVERRIDE found in localStorage', e);
       }
@@ -33,7 +35,8 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
-    return (await response.json()) as RemoteConfig;
+    const data = await response.json();
+    return sanitizeObject(data) as RemoteConfig;
   } catch (error) {
     globalThis.console.error('Failed to load remote configuration from CDN', error);
     return { remotes: {} };
@@ -55,7 +58,8 @@ export async function buildMergedManifest(cdnRemotes: Record<string, string>): P
     clearTimeout(timeoutId);
 
     if (response.ok) {
-      localManifest = (await response.json()) as Record<string, string>;
+      const data = await response.json();
+      localManifest = sanitizeObject(data) as Record<string, string>;
     }
   } catch (error) {
     globalThis.console.warn('Local federation.manifest.json not found or inaccessible', error);


### PR DESCRIPTION
This PR implements security hardening against **Prototype Pollution** during JSON parsing.

### 💡 Vulnerability
The application was using `JSON.parse()` without any sanitization on data coming from `localStorage` (which can be manipulated by users or XSS) and remote configuration files (which could be compromised). Standard `JSON.parse()` processes special keys like `__proto__`, `constructor`, and `prototype`, which can lead to Prototype Pollution when these objects are merged or used in application logic.

### 🔧 Fix
1.  **Shared Security Utilities**: Created `prototypePollutionReviver` for use as a `JSON.parse` reviver and a recursive `sanitizeObject` function in `@hunt-the-bishomalo/shared-util`.
2.  **Harden LocalstorageService**: Integrated `prototypePollutionReviver` into `LocalstorageService.getValue` to ensure all data retrieved from local storage is sanitized.
3.  **Harden config-loader**: Integrated both `prototypePollutionReviver` (for overrides) and `sanitizeObject` (for remote/local manifests) into the MFE configuration loading sequence.

### ✅ Verification
-   Created comprehensive unit tests for the new security utilities.
-   Added a regression test in `LocalstorageService` to ensure it correctly strips `__proto__`.
-   Verified that all existing tests for `config-loader` and the rest of the workspace pass.
-   Successfully built the application.

This change adheres to the defense-in-depth principle and ensures that external data entry points are properly neutralized.

---
*PR created automatically by Jules for task [17223823962247146897](https://jules.google.com/task/17223823962247146897) started by @chdelucia*