### PR TITLE
🎨 Palette: Improve accessibility and tactile feedback in game configuration

### DIFF
--- a/libs/config/feature/src/lib/game-config.component.html
+++ b/libs/config/feature/src/lib/game-config.component.html
@@ -7,13 +7,22 @@
     @let playerState = configForm.player();
     <label for="player">{{ 'config.playerNameLabel' | transloco }}</label>
     <div class="input-wrapper">
-      <input id="player" type="text" [formField]="configForm.player" />
-      <span class="char-counter" [class.limit-reached]="playerState.value().length >= 20">
+      <input
+        id="player"
+        type="text"
+        [formField]="configForm.player"
+        aria-describedby="player-counter player-error"
+      />
+      <span
+        id="player-counter"
+        class="char-counter"
+        [class.limit-reached]="playerState.value().length >= 20"
+      >
         {{ playerState.value().length }}/20
       </span>
     </div>
     @if (playerState.touched() && playerState.errors().length > 0) {
-      <span class="error-message" role="alert">
+      <span id="player-error" class="error-message" role="alert">
         {{ 'config.error.' + playerState.errors()[0].kind | transloco }}
       </span>
     }
@@ -21,7 +30,7 @@
 
   <div class="form-group">
     <label for="difficulty">{{ 'config.difficultyLabel' | transloco }}</label>
-    <select id="difficulty" [formField]="configForm.difficulty">
+    <select id="difficulty" [formField]="configForm.difficulty" aria-describedby="difficulty-desc">
       <option value="easy">{{ 'config.difficultyEasy' | transloco }}</option>
       <option value="normal">{{ 'config.difficultyNormal' | transloco }}</option>
       <option value="hard">{{ 'config.difficultyHard' | transloco }}</option>
@@ -30,7 +39,7 @@
 
   @let options = configs[this.model().difficulty];
 
-  <div class="difficulty-description">
+  <div id="difficulty-desc" class="difficulty-description">
     <p>
       {{
       'config.difficultyDescription'

--- a/libs/config/feature/src/lib/game-config.component.scss
+++ b/libs/config/feature/src/lib/game-config.component.scss
@@ -89,6 +89,10 @@
     &:hover {
       background-color: var(--color-button-hover);
     }
+
+    &:active {
+      transform: translateY(2px);
+    }
   }
 }
 
@@ -123,6 +127,10 @@
   &:focus-within {
     outline: 3px solid var(--color-focus);
     outline-offset: 2px;
+  }
+
+  &:active {
+    transform: translateY(2px);
   }
 }
 

--- a/libs/config/feature/src/lib/game-config.component.spec.ts
+++ b/libs/config/feature/src/lib/game-config.component.spec.ts
@@ -144,4 +144,28 @@ describe('GameConfigComponent', () => {
     expect(charCounter).toBeTruthy();
     expect(charCounter?.textContent).toContain(`${playerName.length}/20`);
   });
+
+  it('should have accessibility attributes', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const playerInput = compiled.querySelector('#player');
+    const playerCounter = compiled.querySelector('#player-counter');
+    const difficultySelect = compiled.querySelector('#difficulty');
+    const difficultyDesc = compiled.querySelector('#difficulty-desc');
+
+    expect(playerInput?.getAttribute('aria-describedby')).toBe('player-counter player-error');
+    expect(playerCounter?.id).toBe('player-counter');
+    expect(difficultySelect?.getAttribute('aria-describedby')).toBe('difficulty-desc');
+    expect(difficultyDesc?.id).toBe('difficulty-desc');
+  });
+
+  it('should show error message with correct id when player name is invalid and touched', () => {
+    component.model.update((m) => ({ ...m, player: '' }));
+    component.configForm.player().markAsTouched();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const errorMessage = compiled.querySelector('.error-message');
+    expect(errorMessage).toBeTruthy();
+    expect(errorMessage?.id).toBe('player-error');
+  });
 });


### PR DESCRIPTION
### 🎨 Palette: Improve accessibility and tactile feedback in game configuration

#### 💡 What
Enhanced the `GameConfigComponent` with:
1.  **Accessibility Links:** Connected the player name input and difficulty selection dropdown to their respective helper texts and error messages using `aria-describedby`.
2.  **Tactile Feedback:** Added an `:active` state transform (`translateY(2px)`) to the "Play" button and character selection buttons to provide immediate visual confirmation of clicks/taps.

#### 🎯 Why
- **Accessibility:** Screen reader users previously lacked the context of the character counter, error messages, and difficulty details when focusing on the associated inputs.
- **Micro-UX:** Interactive elements felt "flat" without tactile feedback, making the interface less responsive to user actions.

#### ♿ Accessibility
- Associated `#player` with `#player-counter` and `#player-error`.
- Associated `#difficulty` with `#difficulty-desc`.
- Ensured IDs are unique and correctly mapped.

#### 🔬 Verification
- **Unit Tests:** Updated `game-config.component.spec.ts` to assert the presence of `aria-describedby` attributes and matching IDs.
- **Visual Verification:** Used a Playwright script to capture the form state and verify the visual presence of the improved elements.
- **Workspace Health:** Ran `bun x nx run-many -t test lint --all` to ensure no regressions.

#### 📸 Before/After
- **Before:** Inputs were isolated from their descriptions. No visual shift on click.
- **After:** Inputs are programmatically linked to descriptions. Subtle 2px "press" effect on interactive elements.

---
*PR created automatically by Jules for task [17582678873909569053](https://jules.google.com/task/17582678873909569053) started by @chdelucia*