### PR TITLE
⚡ Bolt: hoist Set allocations in BoardGeneratorService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2026-04-05 - [Specific Dependency for Derived Computed Signals]
 **Learning:** Derived computed signals (like `hasLantern`) that depend on broad state objects (like `hunter`) will re-evaluate whenever any property of that object changes (e.g., position), even if the relevant property (e.g., `inventory`) remains the same.
 **Action:** Make derived computed signals depend on the most granular computed signals available (e.g., `inventory()`) instead of broad state signals (e.g., `hunter()`) to fully leverage signal memoization and prevent redundant re-evaluations during frequent state changes like movement.
+
+## 2025-05-15 - [Hoisting Set allocations in BoardGeneratorService]
+**Learning:** Creating new Set instances within loops or as default function parameters in frequently called services (like BoardGeneratorService during level initialization) leads to unnecessary object allocation and garbage collection pressure.
+**Action:** Hoist static exclusion sets or configuration objects to static readonly constants to reuse the same instance and improve performance in initialization paths.

--- a/libs/game/data-access/src/lib/board-generator.service.ts
+++ b/libs/game/data-access/src/lib/board-generator.service.ts
@@ -3,6 +3,9 @@ import { Cell, CELL_CONTENTS, CellContentType, GameSettings } from '@hunt-the-bi
 
 @Injectable({ providedIn: 'root' })
 export class BoardGeneratorService {
+  private static readonly START_CELL_EXCLUSION = new Set(['0,0']);
+  private static readonly PIT_EXCLUSION = new Set(['0,0', '0,1', '1,0']);
+
   createBoard(settings: GameSettings): Cell[][] {
     return Array.from({ length: settings.size }, (_, x) =>
       Array.from({ length: settings.size }, (_, y) => ({ x, y, visited: false })),
@@ -22,7 +25,8 @@ export class BoardGeneratorService {
 
   placePits(board: Cell[][], settings: GameSettings): void {
     for (let i = 0; i < settings.pits; i++) {
-      this.placeRandom(board, settings, new Set(['0,0', '0,1', '1,0'])).content = CELL_CONTENTS.pit;
+      this.placeRandom(board, settings, BoardGeneratorService.PIT_EXCLUSION).content =
+        CELL_CONTENTS.pit;
     }
   }
 
@@ -39,7 +43,7 @@ export class BoardGeneratorService {
     dragonballs: number | undefined,
   ): void {
     const { difficulty, size } = settings;
-    const ex = new Set(['0,0']);
+    const ex = BoardGeneratorService.START_CELL_EXCLUSION;
     const chance = (base: number, max: number) =>
       Math.min(base + ((size - 4) / (difficulty.maxLevels - 4)) * (max - base), max);
 
@@ -54,7 +58,11 @@ export class BoardGeneratorService {
     }
   }
 
-  private placeRandom(board: Cell[][], settings: GameSettings, excluded = new Set(['0,0'])): Cell {
+  private placeRandom(
+    board: Cell[][],
+    settings: GameSettings,
+    excluded = BoardGeneratorService.START_CELL_EXCLUSION,
+  ): Cell {
     const size = settings.size;
     let cell: Cell;
     do {


### PR DESCRIPTION
💡 What: Optimized `BoardGeneratorService` by hoisting `Set` allocations into `private static readonly` constants.
🎯 Why: Reducing object allocation overhead and garbage collection pressure during board generation, especially when multiple items are placed.
📊 Impact: Decreases memory churn and speeds up level initialization by reusing static exclusion sets instead of recreating them in loops.
🔬 Measurement: Verified that `BoardGeneratorService` logic remains intact via unit tests; visually confirmed changes in source code.

---
*PR created automatically by Jules for task [7134208967298471093](https://jules.google.com/task/7134208967298471093) started by @chdelucia*