### PR TITLE
🛡️ Sentinel: [security improvement] Harden JSON.parse against Prototype Pollution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -48,4 +48,9 @@
 **Vulnerability:** Sentry's `tracePropagationTargets` used loose string matches and unanchored regular expressions, which could allow sensitive tracing headers (`sentry-trace`, `baggage`) to be leaked to malicious domains that included the whitelisted domain as a substring or prefix (e.g., `hunt-the-bishomalo.vercel.app.malicious.com`).
 **Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
 **Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
+
+## 2025-05-24 - [Harden JSON.parse against Prototype Pollution]
+**Vulnerability:** The application used `JSON.parse` on untrusted data from `localStorage` without a reviver, making it susceptible to Prototype Pollution if malicious keys like `__proto__` were present.
+**Learning:** Even data stored in `localStorage` should be treated as untrusted, especially in applications that allow configuration overrides via storage. Global objects can be compromised if JSON parsing isn't hardened.
+**Prevention:** Always use a reviver function with `JSON.parse` to strip forbidden keys (`__proto__`, `constructor`, `prototype`). Centralize this logic in a security utility and apply it to all data access services.
 >>>>>>> master

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.spec.ts
@@ -75,4 +75,28 @@ describe('LocalstorageService', () => {
       expect(localStorage.length).toBe(0);
     });
   });
+
+  describe('Security', () => {
+    it('should strip prototype pollution keys when getting value', () => {
+      const maliciousData = '{"foo":"bar","__proto__":{"polluted":"yes"}}';
+      localStorage.setItem('malicious', maliciousData);
+
+      const result = service.getValue<any>('malicious');
+
+      expect(result.foo).toBe('bar');
+      // Assert it is not an own property. Direct access may still return Object.prototype
+      expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(false);
+      expect((result as any).polluted).toBeUndefined();
+    });
+
+    it('should strip constructor and prototype keys', () => {
+      const maliciousData = '{"constructor":{"polluted":"yes"},"prototype":{"polluted":"yes"}}';
+      localStorage.setItem('malicious', maliciousData);
+
+      const result = service.getValue<any>('malicious');
+
+      expect(result.constructor).not.toEqual({ polluted: 'yes' });
+      expect(result.prototype).toBeUndefined();
+    });
+  });
 });

--- a/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
+++ b/libs/core/data-access/src/lib/services/localstorage/localstorage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, isDevMode } from '@angular/core';
 import { ILocalstorageService } from '@hunt-the-bishomalo/core/api';
+import { prototypePollutionReviver } from '@hunt-the-bishomalo/shared-util';
 
 @Injectable({
   providedIn: 'root',
@@ -12,7 +13,7 @@ export class LocalstorageService implements ILocalstorageService {
     }
 
     try {
-      return JSON.parse(item);
+      return JSON.parse(item, prototypePollutionReviver);
     } catch (e) {
       if (isDevMode()) console.log(e);
       return null;

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/transloco-testing';
+export * from './lib/security.util';

--- a/libs/shared/util/src/lib/security.util.spec.ts
+++ b/libs/shared/util/src/lib/security.util.spec.ts
@@ -1,0 +1,46 @@
+import { prototypePollutionReviver, sanitizeObject } from './security.util';
+
+describe('Security Utils', () => {
+  describe('prototypePollutionReviver', () => {
+    it('should strip forbidden keys', () => {
+      const json = '{"foo":"bar","__proto__":{"polluted":"yes"},"constructor":"danger","prototype":"danger"}';
+      const parsed = JSON.parse(json, prototypePollutionReviver);
+
+      expect(parsed.foo).toBe('bar');
+      expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(parsed, 'constructor')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(parsed, 'prototype')).toBe(false);
+    });
+  });
+
+  describe('sanitizeObject', () => {
+    it('should recursively strip forbidden keys', () => {
+      const obj = {
+        a: 1,
+        __proto__: { polluted: 'yes' },
+        nested: {
+          b: 2,
+          constructor: { dangerous: true },
+          arr: [
+            { c: 3, prototype: 'danger' }
+          ]
+        }
+      };
+
+      const sanitized = sanitizeObject(obj);
+
+      expect(sanitized.a).toBe(1);
+      expect(Object.prototype.hasOwnProperty.call(sanitized, '__proto__')).toBe(false);
+      expect(sanitized.nested.b).toBe(2);
+      expect(Object.prototype.hasOwnProperty.call(sanitized.nested, 'constructor')).toBe(false);
+      expect(sanitized.nested.arr[0].c).toBe(3);
+      expect(Object.prototype.hasOwnProperty.call(sanitized.nested.arr[0], 'prototype')).toBe(false);
+    });
+
+    it('should handle null and primitives', () => {
+      expect(sanitizeObject(null)).toBeNull();
+      expect(sanitizeObject(123)).toBe(123);
+      expect(sanitizeObject('str')).toBe('str');
+    });
+  });
+});

--- a/libs/shared/util/src/lib/security.util.ts
+++ b/libs/shared/util/src/lib/security.util.ts
@@ -1,0 +1,34 @@
+const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * A JSON.parse reviver that strips forbidden keys to prevent prototype pollution.
+ */
+export function prototypePollutionReviver(key: string, value: unknown): unknown {
+  if (FORBIDDEN_KEYS.includes(key)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Recursively sanitizes an object by removing forbidden keys.
+ */
+export function sanitizeObject<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => sanitizeObject(item)) as unknown as T;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  const typedObj = obj as Record<string, unknown>;
+
+  for (const key in typedObj) {
+    if (Object.prototype.hasOwnProperty.call(typedObj, key) && !FORBIDDEN_KEYS.includes(key)) {
+      sanitized[key] = sanitizeObject(typedObj[key]);
+    }
+  }
+  return sanitized as T;
+}

--- a/src/app/utils/config-loader.ts
+++ b/src/app/utils/config-loader.ts
@@ -1,3 +1,5 @@
+import { prototypePollutionReviver } from '@hunt-the-bishomalo/shared-util';
+
 export interface RemoteConfig {
   remotes: Record<string, string>;
 }
@@ -15,7 +17,7 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
     const localOverride = localStorage.getItem('MFE_REMOTES_OVERRIDE');
     if (localOverride) {
       try {
-        return JSON.parse(localOverride) as RemoteConfig;
+        return JSON.parse(localOverride, prototypePollutionReviver) as RemoteConfig;
       } catch (e) {
         globalThis.console.warn('Invalid MFE_REMOTES_OVERRIDE found in localStorage', e);
       }


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Harden JSON.parse against Prototype Pollution

🚨 Severity: MEDIUM
💡 Vulnerability: Prototype Pollution via `JSON.parse` on untrusted data.
🎯 Impact: An attacker could inject malicious keys like `__proto__` into `localStorage`, which when parsed by the application, could pollute the global `Object.prototype`, leading to unexpected behavior or security bypasses.
🔧 Fix: Implemented a centralized `prototypePollutionReviver` that strips forbidden keys (`__proto__`, `constructor`, `prototype`) during `JSON.parse`. Applied this reviver to the `LocalstorageService` and bootstrap `config-loader`.
✅ Verification: Added unit tests in `security.util.spec.ts` and `localstorage.service.spec.ts` that attempt to inject forbidden keys and verify they are stripped (not present as own properties). All tests and lint pass.

---
*PR created automatically by Jules for task [12229479363697325468](https://jules.google.com/task/12229479363697325468) started by @chdelucia*