### PR TITLE
🎨 Palette: [UX improvement] Fix Wumpus death flow and map revelation

### DIFF
--- a/libs/game/api/src/lib/game-facade.interface.ts
+++ b/libs/game/api/src/lib/game-facade.interface.ts
@@ -1,5 +1,5 @@
 import { InjectionToken, Signal } from '@angular/core';
-import { Cell, GameSettings, GameItem } from '@hunt-the-bishomalo/shared-data';
+import { Cell, GameSettings, GameItem, GameState } from '@hunt-the-bishomalo/shared-data';
 
 export interface IGameFacade {
   readonly board: Signal<Cell[][]>;
@@ -33,6 +33,7 @@ export interface IGameFacade {
   newGame(): void;
   initGame(): void;
   toggleSound(): void;
+  updateGame(partial: Partial<GameState>): void;
 }
 
 export const GAME_FACADE_TOKEN = new InjectionToken<IGameFacade>('GAME_FACADE_TOKEN');

--- a/libs/game/data-access/src/lib/game.facade.ts
+++ b/libs/game/data-access/src/lib/game.facade.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { GAME_STORE_TOKEN } from '@hunt-the-bishomalo/core/api';
 import { IGameFacade, GAME_ENGINE_TOKEN } from '@hunt-the-bishomalo/game/api';
+import { GameState } from '@hunt-the-bishomalo/shared-data';
 
 @Injectable({ providedIn: 'root' })
 export class GameFacade implements IGameFacade {
@@ -61,5 +62,9 @@ export class GameFacade implements IGameFacade {
 
   toggleSound(): void {
     this.store.toggleSound();
+  }
+
+  updateGame(partial: Partial<GameState>): void {
+    this.store.updateGame(partial);
   }
 }

--- a/libs/game/feature/src/lib/game.spec.ts
+++ b/libs/game/feature/src/lib/game.spec.ts
@@ -54,6 +54,7 @@ describe('Game', () => {
     turnLeft: jest.fn(),
     turnRight: jest.fn(),
     toggleSound: jest.fn(),
+    updateGame: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -91,20 +92,9 @@ describe('Game', () => {
     expect(component.facade.deathByWumpus()).toBe(false);
   });
 
-  it('should handle close and navigate to RESULTS when lives are 0', () => {
-    mockGameFacade.lives.set(0);
+  it('should handle close and update game state', () => {
     component.handleClose();
-    expect(router.navigate).toHaveBeenCalledWith([RouteTypes.RESULTS], {
-      state: { fromSecretPath: true },
-    });
-  });
-
-  it('should call initGame when lives > 0', () => {
-    jest.clearAllMocks();
-    mockGameFacade.lives.set(3);
-    component.handleClose();
-    expect(mockGameFacade.initGame).toHaveBeenCalled();
-    expect(mockGameFacade.newGame).not.toHaveBeenCalled();
+    expect(mockGameFacade.updateGame).toHaveBeenCalledWith({ deathByWumpus: false });
   });
 
   it('should call facade performAction on mobile shoot', () => {

--- a/libs/game/feature/src/lib/game.ts
+++ b/libs/game/feature/src/lib/game.ts
@@ -42,13 +42,7 @@ export class Game {
   readonly emptyInventory: GameItem[] = [];
 
   handleClose(): void {
-    if (this.facade.lives() > 0) {
-      this.facade.initGame();
-    } else {
-      this.router.navigate([RouteTypes.RESULTS], {
-        state: { fromSecretPath: true },
-      });
-    }
+    this.facade.updateGame({ deathByWumpus: false });
   }
 
   handleMobileShootArrow(): void {

--- a/libs/game/ui/src/lib/animations/attack/wumpus-attack-animation.component.html
+++ b/libs/game/ui/src/lib/animations/attack/wumpus-attack-animation.component.html
@@ -1,5 +1,13 @@
 @let selected = selectedChar();
-<div class="overlay">
+<div
+  class="overlay"
+  (click)="closeAnimation.emit()"
+  (keydown.enter)="closeAnimation.emit()"
+  (keydown.space)="closeAnimation.emit()"
+  tabindex="0"
+  role="button"
+  aria-label="Dismiss death animation"
+>
   <div class="animation step-{{ step() }}">
     <div
       class="player"

--- a/libs/game/ui/src/lib/animations/attack/wumpus-attack-animation.component.spec.ts
+++ b/libs/game/ui/src/lib/animations/attack/wumpus-attack-animation.component.spec.ts
@@ -25,20 +25,17 @@ describe('AppWumpusAttackAnimationComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set step to 5 immediately and emit closeAnimation', (done) => {
+  it('should set step to 5 immediately and NOT emit closeAnimation automatically', () => {
     const testFixture = TestBed.createComponent(AppWumpusAttackAnimationComponent);
     const testComponent = testFixture.componentInstance;
     testFixture.componentRef.setInput('selectedChar', 'default');
 
     const spy = jest.spyOn(testComponent.closeAnimation, 'emit');
 
-    testComponent.closeAnimation.subscribe(() => {
-      expect(testComponent.step()).toBe(5);
-      expect(spy).toHaveBeenCalled();
-      done();
-    });
-
     testFixture.detectChanges();
+
+    expect(testComponent.step()).toBe(5);
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('should return correct player position', () => {

--- a/libs/game/ui/src/lib/animations/attack/wumpus-attack-animation.component.ts
+++ b/libs/game/ui/src/lib/animations/attack/wumpus-attack-animation.component.ts
@@ -25,7 +25,6 @@ export class AppWumpusAttackAnimationComponent implements OnInit {
 
   ngOnInit(): void {
     this.step.set(5);
-    this.closeAnimation.emit();
   }
 
   readonly getPlayerLeft = computed(() => {


### PR DESCRIPTION
### What
- Exposed `updateGame` in `IGameFacade` and implemented it in `GameFacade`.
- Modified `Game` component to only reset the `deathByWumpus` flag when closing the death animation, instead of immediately restarting.
- Updated `AppWumpusAttackAnimationComponent` to remove the automatic emission of `closeAnimation` in `ngOnInit`.
- Added click and keyboard handlers to the death animation overlay for manual dismissal.

### Why
- To align the Wumpus death experience with the "pit" death behavior, ensuring the player can see the death animation and the revealed map before the game state is reset. This addresses the issue where the game would restart directly without showing the animation or the map.

### Accessibility
- Added `tabindex="0"`, `role="button"`, `aria-label`, and keyboard listeners for `Enter` and `Space` to the Wumpus attack animation overlay to ensure it is focusable and dismissible by keyboard and screen reader users.

### Before/After
- **Before**: When killed by a Wumpus, the death animation was instantly dismissed, and the game would either restart (if lives > 0) or navigate to the results screen (if lives == 0) immediately, preventing the player from seeing the revealed map.
- **After**: The Wumpus death animation remains on screen until the user manually dismisses it. Once closed, the user can see the fully revealed map. The user can then choose when to restart the game using the manual "Retry" button.

### Verification
- Verified with unit tests in `libs/game/feature`, `libs/game/ui`, and `libs/game/data-access`.
- Verified lint compliance for the new accessibility attributes.

---
*PR created automatically by Jules for task [956521776465362988](https://jules.google.com/task/956521776465362988) started by @chdelucia*