### PR TITLE
🛡️ Sentinel: [security improvement] Harden Native Federation MFE Config Loader and Route Resilience

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Sentry's `tracePropagationTargets` used loose string matches and unanchored regular expressions, which could allow sensitive tracing headers (`sentry-trace`, `baggage`) to be leaked to malicious domains that included the whitelisted domain as a substring or prefix (e.g., `hunt-the-bishomalo.vercel.app.malicious.com`).
 **Learning:** String entries in `tracePropagationTargets` are treated as substring matches by Sentry. Without anchors (`^`, `$`) and proper delimiter handling, whitelists can be easily bypassed via subdomain or path-based exploitation.
 **Prevention:** Always use strict, anchored regular expressions (e.g., `/^https:\/\/domain\.com($|\/)/`) for `tracePropagationTargets` to ensure tracing headers are only propagated to verified, exact origins.
+
+## 2026-04-06 - [Prototype Pollution Protection in MFE Config Loader]
+**Vulnerability:** Parsing `MFE_REMOTES_OVERRIDE` from `localStorage` or JSON configs without custom revivers could allow prototype pollution payload injection into the runtime object model.
+**Learning:** `JSON.parse` inherits from `Object.prototype`. Unsanitized object parsing allows attackers or malicious scripts to pollute key properties like `__proto__` or `constructor`.
+**Prevention:** Always pass a custom reviver to `JSON.parse` that filters out `__proto__`, `constructor`, and `prototype`, and verify own-property ownership via `Object.prototype.hasOwnProperty.call`.

--- a/apps/achievements-remote/src/main.ts
+++ b/apps/achievements-remote/src/main.ts
@@ -1,6 +1,5 @@
 import { initFederation } from '@angular-architects/native-federation';
 
 initFederation()
-  .catch(err => console.error(err))
   .then(() => import('./bootstrap'))
-  .catch(err => console.error(err));
+  .catch((err) => console.error('Failed to initialize federation in achievements-remote:', err));

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -11,6 +11,7 @@ import {
   GAME_EVENT_SERVICE_TOKEN,
   MINI_BUS_SERVICE_TOKEN,
 } from '@hunt-the-bishomalo/core/api';
+import { REMOTE_CONFIG_TOKEN } from '@hunt-the-bishomalo/core/data-access';
 import { GAME_ENGINE_TOKEN } from '@hunt-the-bishomalo/game/api';
 import { signal, Component, Input, NO_ERRORS_SCHEMA } from '@angular/core';
 import { Subject, of } from 'rxjs';
@@ -80,6 +81,10 @@ describe('AppComponent', () => {
         },
         { provide: MINI_BUS_SERVICE_TOKEN, useValue: { emit: jest.fn(), listen: jest.fn() } },
         {
+          provide: REMOTE_CONFIG_TOKEN,
+          useValue: { remotes: { achievements: 'http://localhost:4201/remoteEntry.js' } },
+        },
+        {
           provide: GAME_STORE_TOKEN,
           useValue: {
             size: signal(4),
@@ -128,4 +133,7 @@ describe('AppComponent', () => {
     expect(component.game).toBeDefined();
   });
 
+  it('should initialize and trigger remote preloading on ngOnInit', () => {
+    expect(() => component.ngOnInit()).not.toThrow();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,9 +53,10 @@ export class AppComponent implements OnInit {
 
   private preloadRemotes(): void {
     const remotes = this.remoteConfig?.remotes;
-    if (!remotes) return;
+    if (!remotes || typeof remotes !== 'object') return;
 
     Object.keys(remotes).forEach((remoteName) => {
+      if (!remoteName) return;
       loadRemoteModule(remoteName, './Routes').catch((err) => {
         globalThis.console.warn(`Preload failed for remote: ${remoteName}`, err);
       });

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -20,6 +20,20 @@ describe('appRoutes', () => {
     }
   });
 
+  it('should fallback gracefully if remote loading fails', async () => {
+    (loadRemoteModule as jest.Mock).mockRejectedValueOnce(new Error('Network offline'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const route = appRoutes.find((r) => r.path === 'logros');
+    expect(route).toBeDefined();
+    if (route?.loadChildren) {
+      const fallbackRoutes = await (route.loadChildren() as any);
+      expect(fallbackRoutes).toBeDefined();
+      expect(Array.isArray(fallbackRoutes)).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+    }
+  });
+
   it('should have the expected number of routes', () => {
     expect(appRoutes.length).toBeGreaterThan(0);
   });

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,7 +8,17 @@ export const appRoutes: Route[] = [
   {
     path: RouteTypes.ACHIEVEMENTS,
     loadChildren: () =>
-      loadRemoteModule('achievements', './Routes').then((mod) => mod.achievementsRoutes),
+      loadRemoteModule('achievements', './Routes')
+        .then((mod) => mod.achievementsRoutes)
+        .catch((err) => {
+          globalThis.console.error('Failed to load achievements remote module:', err);
+          return import('./pages').then((mod) => [
+            {
+              path: '',
+              component: mod.NotFoundComponent,
+            },
+          ]);
+        }),
     title: 'Logros | Bisho malo',
     data: { preload: true },
   },

--- a/src/app/utils/config-loader.spec.ts
+++ b/src/app/utils/config-loader.spec.ts
@@ -1,9 +1,26 @@
-import { fetchRemoteConfig, fetchLocalManifest, buildMergedManifest } from './config-loader';
+import { fetchRemoteConfig, fetchLocalManifest, buildMergedManifest, safeJsonParse } from './config-loader';
 
 describe('config-loader', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     localStorage.clear();
+  });
+
+  describe('safeJsonParse', () => {
+    it('should neutralize prototype pollution payload keys', () => {
+      const payload = '{"remotes":{"mfe1":"url1"},"__proto__":{"polluted":true}}';
+      const parsed = safeJsonParse<{ remotes: Record<string, string> }>(payload);
+      expect(parsed).toBeDefined();
+      if (parsed) {
+        expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(false);
+        expect((parsed as any).polluted).toBeUndefined();
+      }
+    });
+
+    it('should return null for malformed JSON', () => {
+      const parsed = safeJsonParse('{invalid json}');
+      expect(parsed).toBeNull();
+    });
   });
 
   describe('fetchRemoteConfig', () => {
@@ -122,6 +139,11 @@ describe('config-loader', () => {
       const result = buildMergedManifest(localManifest, cdnRemotes);
 
       expect(result).toEqual({ ...localManifest, ...cdnRemotes });
+    });
+
+    it('should safely handle null or undefined inputs', () => {
+      const result = buildMergedManifest(null, undefined);
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/app/utils/config-loader.ts
+++ b/src/app/utils/config-loader.ts
@@ -3,8 +3,39 @@ export interface RemoteConfig {
 }
 
 /**
+ * Reviver function for JSON.parse to neutralize prototype pollution keys.
+ */
+function safeJsonReviver(key: string, value: unknown): unknown {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Safely parses JSON string with prototype pollution neutralization.
+ */
+export function safeJsonParse<T>(jsonString: string): T | null {
+  try {
+    const parsed = JSON.parse(jsonString, safeJsonReviver) as T;
+    if (parsed && typeof parsed === 'object') {
+      if (
+        Object.prototype.hasOwnProperty.call(parsed, '__proto__') ||
+        Object.prototype.hasOwnProperty.call(parsed, 'constructor') ||
+        Object.prototype.hasOwnProperty.call(parsed, 'prototype')
+      ) {
+        return null;
+      }
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetches the remote configuration from the CDN.
- * Includes a timeout to prevent the application from hanging on slow networks.
+ * Includes override handling in dev mode with prototype pollution protection.
  */
 export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
   const url = isDev
@@ -14,11 +45,11 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
   if (isDev) {
     const localOverride = localStorage.getItem('MFE_REMOTES_OVERRIDE');
     if (localOverride) {
-      try {
-        return JSON.parse(localOverride) as RemoteConfig;
-      } catch (e) {
-        globalThis.console.warn('Invalid MFE_REMOTES_OVERRIDE found in localStorage', e);
+      const parsed = safeJsonParse<RemoteConfig>(localOverride);
+      if (parsed && parsed.remotes && typeof parsed.remotes === 'object') {
+        return parsed;
       }
+      globalThis.console.warn('Invalid MFE_REMOTES_OVERRIDE found in localStorage');
     }
   }
 
@@ -29,7 +60,11 @@ export async function fetchRemoteConfig(isDev: boolean): Promise<RemoteConfig> {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
-    return (await response.json()) as RemoteConfig;
+    const data = (await response.json()) as RemoteConfig;
+    if (data && typeof data === 'object' && data.remotes && typeof data.remotes === 'object') {
+      return data;
+    }
+    return { remotes: {} };
   } catch (error) {
     globalThis.console.error('Failed to load remote configuration from CDN', error);
     return { remotes: {} };
@@ -44,7 +79,10 @@ export async function fetchLocalManifest(): Promise<Record<string, string>> {
     const response = await fetch('federation.manifest.json');
 
     if (response.ok) {
-      return (await response.json()) as Record<string, string>;
+      const data = (await response.json()) as Record<string, string>;
+      if (data && typeof data === 'object') {
+        return data;
+      }
     }
   } catch (error) {
     globalThis.console.warn('Local federation.manifest.json not found or inaccessible', error);
@@ -57,11 +95,14 @@ export async function fetchLocalManifest(): Promise<Record<string, string>> {
  * Remote configurations take precedence over local ones.
  */
 export function buildMergedManifest(
-  localManifest: Record<string, string>,
-  cdnRemotes: Record<string, string>,
+  localManifest?: Record<string, string> | null,
+  cdnRemotes?: Record<string, string> | null,
 ): Record<string, string> {
+  const safeLocal = localManifest && typeof localManifest === 'object' ? localManifest : {};
+  const safeCdn = cdnRemotes && typeof cdnRemotes === 'object' ? cdnRemotes : {};
+
   return {
-    ...localManifest,
-    ...cdnRemotes,
+    ...safeLocal,
+    ...safeCdn,
   };
 }


### PR DESCRIPTION
🚨 Severity: Medium
💡 Vulnerability: Unsanitized JSON parsing in config-loader.ts for MFE overrides (MFE_REMOTES_OVERRIDE) could allow prototype pollution key injection (__proto__, constructor, prototype). Unhandled promise rejections during remote module route loading (loadRemoteModule) caused router navigation crashes when remote MFEs were offline or unreachable.
🎯 Why: To safeguard the host shell against prototype pollution attack vectors and ensure high application availability even when microfrontend remotes experience downtime.
🛠️ Fix:
- Added safeJsonParse in config-loader.ts with a custom reviver filtering out forbidden keys (__proto__, constructor, prototype) and verifying own-property ownership via Object.prototype.hasOwnProperty.call.
- Added defensive null/undefined object handling in buildMergedManifest.
- Added graceful route fallback handling for loadRemoteModule in app.routes.ts so route navigation safely renders a fallback component if a remote module fails to load.
- Guarded preloadRemotes in AppComponent against non-object configs.
- Fixed standalone remote initialization flow in apps/achievements-remote/src/main.ts.
- Updated unit tests in config-loader.spec.ts, app.routes.spec.ts, and app.component.spec.ts.
✅ Verification:
- Executed unit tests, linting, and production build checks across all 35 projects in the workspace (bun x nx run-many -t test lint build --all). All passed successfully.

---
*PR created automatically by Jules for task [5551534566335978014](https://jules.google.com/task/5551534566335978014) started by @chdelucia*