### PR TITLE
⚡ Bolt: optimize signal stores to prevent unnecessary state updates and eliminate I/O side effects

### DIFF
--- a/libs/boss/feature/src/lib/boss-store.ts
+++ b/libs/boss/feature/src/lib/boss-store.ts
@@ -36,6 +36,11 @@ export const BossStore = signalStore(
   withState(initialState),
   withMethods(
     (store, gameSound = inject(GAME_SOUND_TOKEN), translocoService = inject(TranslocoService)) => {
+      const triggerAudio = (sound: GameSound) => {
+        gameSound.stop();
+        gameSound.playSound(sound, false);
+      };
+
       const getHint = (grid: BossCell[][], x: number, y: number): string => {
         const row = grid[x];
         const col = grid.map((r) => r[y]);
@@ -58,8 +63,7 @@ export const BossStore = signalStore(
 
       return {
         resetGame(settings: GameSettings) {
-          gameSound.stop();
-          gameSound.playSound(GameSound.BATTLE, false);
+          triggerAudio(GameSound.BATTLE);
 
           const gridSize = 5;
           const bossParts = 5;
@@ -107,6 +111,7 @@ export const BossStore = signalStore(
           let newPlayerLives = playerLives();
           let newGameOver = gameOver();
           let newMessage = message();
+          let soundToPlay: GameSound | null = null;
 
           const updatedGrid = grid().map((row) =>
             row.map((c) => {
@@ -130,8 +135,7 @@ export const BossStore = signalStore(
           if (newBossRemaining === 0) {
             newMessage = translocoService.translate('bossFightMessages.bossDefeated');
             newGameOver = true;
-            gameSound.stop();
-            gameSound.playSound(GameSound.FINISH, false);
+            soundToPlay = GameSound.FINISH;
           } else if (newPlayerLives === 0) {
             newMessage = translocoService.translate('bossFightMessages.playerDefeated');
             const revealedGrid = revealAllBossParts(updatedGrid);
@@ -141,8 +145,7 @@ export const BossStore = signalStore(
               message: newMessage,
               gameOver: true,
             });
-            gameSound.stop();
-            gameSound.playSound(GameSound.PITDIE, false);
+            triggerAudio(GameSound.PITDIE);
             return;
           }
 
@@ -153,10 +156,14 @@ export const BossStore = signalStore(
             message: newMessage,
             gameOver: newGameOver,
           });
+
+          if (soundToPlay) {
+            triggerAudio(soundToPlay);
+          }
         },
 
         setMessage(message: string) {
-          patchState(store, { message });
+          patchState(store, (state) => (state.message === message ? state : { message }));
         },
       };
     },

--- a/libs/core/data-access/src/lib/store/features/config.feature.ts
+++ b/libs/core/data-access/src/lib/store/features/config.feature.ts
@@ -1,4 +1,4 @@
-import { computed, inject } from '@angular/core';
+import { computed } from '@angular/core';
 import {
   signalStoreFeature,
   withState,
@@ -7,7 +7,6 @@ import {
   patchState,
 } from '@ngrx/signals';
 import { GameSettings, Chars } from '@hunt-the-bishomalo/shared-data';
-import { LocalstorageService } from '../../services';
 
 export const storageSettingsKey = 'hunt_the_bishomalo_settings';
 
@@ -26,16 +25,23 @@ export function withConfigFeature() {
       startTime: computed(() => settings().startTime),
       soundEnabled: computed(() => settings().soundEnabled ?? true),
     })),
-    withMethods((store, localStorage = inject(LocalstorageService)) => ({
+    withMethods((store) => ({
       $_updateSettings(settings: GameSettings) {
-        patchState(store, { settings });
-        localStorage.setValue(storageSettingsKey, settings);
+        patchState(store, (state) => (state.settings === settings ? state : { settings }));
       },
       $_setUnlockedChars(unlockedChars: Chars[]) {
-        patchState(store, { unlockedChars });
+        patchState(store, (state) => {
+          if (
+            state.unlockedChars === unlockedChars ||
+            (state.unlockedChars.length === unlockedChars.length &&
+              state.unlockedChars.every((val, index) => val === unlockedChars[index]))
+          ) {
+            return state;
+          }
+          return { unlockedChars };
+        });
       },
       $_resetConfig() {
-        localStorage.clearValue(storageSettingsKey);
         patchState(store, { settings: {} as GameSettings });
       },
     })),

--- a/libs/core/data-access/src/lib/store/features/game-status.feature.ts
+++ b/libs/core/data-access/src/lib/store/features/game-status.feature.ts
@@ -29,10 +29,14 @@ export function withGameStatusFeature() {
         hasWon?: boolean;
         lives?: number;
       }) {
-        patchState(store, (state) => ({ ...state, ...partial }));
+        patchState(store, (state) => {
+          const keys = Object.keys(partial) as (keyof typeof partial)[];
+          const hasChange = keys.some((key) => state[key] !== partial[key]);
+          return hasChange ? { ...state, ...partial } : state;
+        });
       },
       $_setMessage(message: string) {
-        patchState(store, { message });
+        patchState(store, (state) => (state.message === message ? state : { message }));
       },
       $_countWumpusKilled() {
         patchState(store, (state) => ({ wumpusKilled: state.wumpusKilled + 1 }));

--- a/libs/core/data-access/src/lib/store/features/hunter.feature.ts
+++ b/libs/core/data-access/src/lib/store/features/hunter.feature.ts
@@ -32,7 +32,11 @@ export function withHunterFeature() {
     })),
     withMethods((store) => ({
       $_updateHunter(partial: Partial<Hunter>) {
-        patchState(store, (state) => ({ hunter: { ...state.hunter, ...partial } }));
+        patchState(store, (state) => {
+          const keys = Object.keys(partial) as (keyof Hunter)[];
+          const hasChange = keys.some((key) => state.hunter[key] !== partial[key]);
+          return hasChange ? { hunter: { ...state.hunter, ...partial } } : state;
+        });
       },
       $_resetHunter() {
         patchState(store, { hunter: initialHunter });

--- a/libs/core/data-access/src/lib/store/game-store.spec.ts
+++ b/libs/core/data-access/src/lib/store/game-store.spec.ts
@@ -72,6 +72,18 @@ describe('GameStore (SignalStore)', () => {
     expect(localStorageServiceMock.setValue).not.toHaveBeenCalled();
   });
 
+  it('should not mutate hunter state reference when updateHunter is called with unchanged values', () => {
+    const initialHunterRef = store.hunter();
+    store.updateHunter({ x: initialHunterRef.x, y: initialHunterRef.y });
+    expect(store.hunter()).toBe(initialHunterRef);
+  });
+
+  it('should not mutate game status state reference when updateGame status is unchanged', () => {
+    const initialMsg = store.message();
+    store.updateGame({ message: initialMsg });
+    expect(store.message()).toBe(initialMsg);
+  });
+
   it('should persist when updating hunter inventory or gold', () => {
     store.updateHunter({ gold: 100 });
     expect(localStorageServiceMock.setValue).toHaveBeenCalledWith('hunt_the_bishomalo_hunter', expect.any(Object));

--- a/libs/core/data-access/src/lib/store/game-store.ts
+++ b/libs/core/data-access/src/lib/store/game-store.ts
@@ -61,6 +61,7 @@ export const GameStore = signalStore(
         store.$_resetHunter();
         store.$_resetGameStatus();
         store.$_resetConfig();
+        localStorage.clearValue(storageSettingsKey);
         const gameData = localStorage.getValue<GameLocalStorageInfo>(storageKey);
         if (gameData) {
           store.$_setUnlockedChars(gameData.unlockedChars);
@@ -79,6 +80,7 @@ export const GameStore = signalStore(
 
         if (settings) {
           store.$_updateSettings(settings);
+          localStorage.setValue(storageSettingsKey, settings);
         }
 
         if (hunter) {
@@ -105,10 +107,12 @@ export const GameStore = signalStore(
       },
 
       toggleSound() {
-        store.$_updateSettings({
+        const newSettings = {
           ...store.settings(),
           soundEnabled: !store.soundEnabled(),
-        });
+        };
+        store.$_updateSettings(newSettings);
+        localStorage.setValue(storageSettingsKey, newSettings);
         persistGameState();
       },
     };


### PR DESCRIPTION
Optimized NgRx SignalStore implementations across the workspace (`GameStore`, `BossStore`, and feature extensions `withHunterFeature`, `withConfigFeature`, and `withGameStatusFeature`):

1. **Eliminated Side Effects in Feature Mutators:** Removed direct `LocalstorageService` I/O operations from `withConfigFeature` methods (`$_updateSettings`, `$_resetConfig`). Centralized `localStorage` persistence in top-level `GameStore` methods (`updateGame`, `resetStore`, `toggleSound`).
2. **Prevented Redundant State Notifications:** Added shallow equality/no-op checks before `patchState` in `$_updateHunter`, `$_updateSettings`, `$_setUnlockedChars`, `$_updateGameStatus`, `$_setMessage`, and `BossStore.setMessage`. When partial patch values equal existing state values, the original state object reference is returned, preventing downstream Angular Signals from triggering unnecessary computations and change detection cycles.
3. **Audio Side-Effect Isolation:** Refactored `BossStore` to isolate sound playback execution from state calculations.
4. **Verification & Tests:** Added unit tests verifying that state references are preserved during no-op updates. Ran full workspace test, lint, and build targets (`bun x nx run-many -t test lint build --all`).

---
*PR created automatically by Jules for task [15257520819000863455](https://jules.google.com/task/15257520819000863455) started by @chdelucia*